### PR TITLE
Added viewing functionality to 'category-routing.js'

### DIFF
--- a/routes/api/category-routes.js
+++ b/routes/api/category-routes.js
@@ -3,14 +3,44 @@ const { Category, Product } = require('../../models');
 
 // The `/api/categories` endpoint
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   // find all categories
   // be sure to include its associated Products
+  try {
+
+    // When a user searches '/api/categories' it will display all the table contents within 'categoryData'
+    const categoryData = await Category.findAll();
+
+    // Then sends the 'categoryData' as a response in JSON format
+    res.status(200).json(categoryData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.get('/:id', (req, res) => {
+router.get('/:id', async (req, res) => {
   // find one category by its `id` value
   // be sure to include its associated Products
+  try {
+
+    // Takes the users ID search and matches it to the same id within the category table/model and stores it within 'categoryData'
+    const categoryData = await Category.findByPk(req.params.id, {
+
+      // It will also respond with the associated Product model of the user searched category ID 
+      include: [{ model: Product }]
+    });
+
+    // If it cannot find an ID that matches to that of the database, it will send back a response stating so
+    if (!categoryData) {
+      res.status(404).json({ message: 'Cannot find category with this id!' });
+      return;
+    }
+
+    // Otherwise it will respond with the stored data in 'categoryData'
+    res.status(200).json(categoryData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 router.post('/', (req, res) => {


### PR DESCRIPTION
Since last push I've been able to successfully seed the database and just need to establish routing across all tables (Categories, Products and Tags) and with this push it is now possible to view the table contents of the Categories table in JSON formatting with a GET request!

You can either view the full table of contents w/ `/api/categories/` or by searching a particular category id w/ `/api/categories/:id` which will display the specific category id and name but also the associated product alongside it.

Here is what I had to setup for both routes: 

- Added `async` to each `router.get` arrow functions so it can return a promise (Lines 6 and 21)
- Created a `Try/Catch` statements to catch any errors for when each is being executed (Lines 9-18 and 24-43)

To view all of the category tables contents, I had to establish `categoryData` which will store all of the tabled contents (including columns) from the category table (Line 12).

When it has all the data needed and the response status is '200' (successful) then it will display all of the stored data within `categoryData` in JSON format when a GET request is made in Insomnia (Line 15).

If there is an error that happens while this is being executed, then the `Try/Catch` statement will catch the error and store it in `err` and respond with it in JSON format (Lines 17 and 41).

The same process goes for when searching for a category ID however slightly different, after a user searches for a specific ID we use `categoryData` to store the matched ID's results (between the users searched ID and an existing category ID within the ecommerce_db) (Line 27).

We use `findByPk()` (A method from Sequelize) to find a single entry to our specification from the category table/model, in this case we're telling it to find the stored category ID that matches that of the users searched ID and to then display the results of the category ID and name as well as the associated product in JSON format (Lines 27-31)

If it cannot find a match between the two ID's then it will display the 'Cannot find category with this id!' message in JSON format (Lines 34-37)

I am now going to implement the same functionality within the `product-routes` and `tag-routes` files