### PR TITLE
Added viewing functionality to 'product-routes.js' and 'tag-routes.js'

### DIFF
--- a/routes/api/product-routes.js
+++ b/routes/api/product-routes.js
@@ -1,18 +1,51 @@
 const router = require('express').Router();
+const { Model } = require('sequelize');
 const { Product, Category, Tag, ProductTag } = require('../../models');
 
 // The `/api/products` endpoint
 
 // get all products
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   // find all products
   // be sure to include its associated Category and Tag data
+  try {
+
+    // When a user searches '/api/products' it will display all the table contents within 'productData'
+    const productData = await Product.findAll({
+      include: [{ model: Category }, { model: Tag, through: Category, as: "tags" }]
+    });
+
+    // Then sends the 'productData' as a response in JSON format
+    res.status(200).json(productData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 // get one product
-router.get('/:id', (req, res) => {
+router.get('/:id', async (req, res) => {
   // find a single product by its `id`
   // be sure to include its associated Category and Tag data
+  try {
+
+    // Takes the users ID search and matches it to the same id within the product table/model and stores it within 'productData'
+    const productData = await Product.findByPk(req.params.id, {
+
+      // It will also respond with the Category model and the associated Tag model of the user searched product ID 
+      include: [{ model: Category }, { model: Tag, through: Category, as: "tags" }]
+    });
+
+    // If it cannot find an ID that matches to that of the database, it will send back a response stating so
+    if (!productData) {
+      res.status(404).json({ message: 'Cannot find category with this id!' });
+      return;
+    }
+
+    // Otherwise it will respond with the stored data in 'productData'
+    res.status(200).json(productData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 // create new product

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -3,14 +3,46 @@ const { Tag, Product, ProductTag } = require('../../models');
 
 // The `/api/tags` endpoint
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   // find all tags
   // be sure to include its associated Product data
+  try {
+
+    // When a user searches '/api/tags' it will display all the table contents from Tag and Product within 'tagData'
+    const tagData = await Tag.findAll({
+      include: [{ model: Product }]
+    });
+
+    // Then sends the 'tagData' as a response in JSON format
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
-router.get('/:id', (req, res) => {
+router.get('/:id', async (req, res) => {
   // find a single tag by its `id`
   // be sure to include its associated Product data
+  try {
+
+    // Takes the users ID search and matches it to the same id within the tag table/model and stores it within 'tagData'
+    const tagData = await Tag.findByPk(req.params.id, {
+
+      // It will also respond with the associated Product model of the user searched tag ID 
+      include: [{ model: Product }]
+    });
+
+    // If it cannot find an ID that matches to that of the database, it will send back a response stating so
+    if (!tagData) {
+      res.status(404).json({ message: 'Cannot find tag with this id!' });
+      return;
+    }
+
+    // Otherwise it will respond with the stored data in 'tagData'
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 router.post('/', (req, res) => {


### PR DESCRIPTION
As stated in the previous push, I took the same functionality/process I did for the viewing/GET request data and took the same approach by reformatting the same code from the 'category-routes.js' file into 'product-routes.js' and 'tag-routes.js'.

The only differences/changes made was how each files GET request pulled in the table/models in JSON formatting:

'product-routes.js' file:

- Had it pull in the Category model/table as well as the Tag model to go through Category as a new table called "tags" (Lines 15 and 35)

'tag-routes.js' file: 

- Had it pull in the Products model/table to associate itself with the Tag model/table (Lines 13 and 32)

Again, everything still functions the exact same way as explained in the previous push for 'category-routes.js', now working on implementing POST, PUT and DELETE for each file.

Most likely doing it for 'category-routes.js' first and then pushing each file change up individually.